### PR TITLE
kinto-http-java-4 no methods should return JSONObject unless necessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,18 @@
             <version>1.6.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.1.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/intesens/kinto_http/Collection.java
+++ b/src/main/java/com/intesens/kinto_http/Collection.java
@@ -1,5 +1,9 @@
 package com.intesens.kinto_http;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import com.mashape.unirest.request.GetRequest;
@@ -13,24 +17,24 @@ public class Collection {
 
     private Bucket bucket;
 
-    private String name;
+    private String id;
 
     /**
      * @param client the {@link KintoClient} used for subsequent requests
      * @param bucket the bucket parent of the collection
-     * @param name the name of the collection
+     * @param id the id of the collection
      */
-    public Collection(KintoClient client, Bucket bucket, String name) {
+    public Collection(KintoClient client, Bucket bucket, String id) {
         this.kintoClient = client;
         this.bucket = bucket;
-        this.name = name;
+        this.id = id;
     }
 
     /**
-     * @return the current collection name
+     * @return the current collection id
      */
-    public String getName() {
-        return name;
+    public String getId() {
+        return id;
     }
 
     /**
@@ -48,25 +52,31 @@ public class Collection {
      */
     public JSONObject getData() throws KintoException, ClientException {
         GetRequest request = kintoClient.request(ENDPOINTS.COLLECTION)
-                .routeParam("bucket", bucket.getName())
-                .routeParam("collection", name);
+                .routeParam("bucket", bucket.getId())
+                .routeParam("collection", id);
         return kintoClient.execute(request);
     }
 
     private GetRequest getListRecordsRequest() {
         return kintoClient.request(ENDPOINTS.RECORDS)
-                .routeParam("bucket", bucket.getName())
-                .routeParam("collection", name);
+                .routeParam("bucket", bucket.getId())
+                .routeParam("collection", id);
     }
 
     /**
      * Retrieve the records list of the current collection
-     * @return the records as a raw {@link JSONObject}
+     * @return the records as a set of {@link JSONObject}
      * @throws KintoException in case of error response from Kinto
      * @throws ClientException in case of transport error
      */
-    public JSONObject listRecords() throws KintoException, ClientException {
-        return kintoClient.execute(getListRecordsRequest());
+    public Set<JSONObject> listRecords() throws KintoException, ClientException {
+        Set<JSONObject> records = new HashSet<>();
+        JSONObject response = kintoClient.execute(getListRecordsRequest());
+        JSONArray data = response.getJSONArray("data");
+        for (int i = 0; i < data.length(); i++) {
+            records.add(data.getJSONObject(i));
+        }
+        return records;
     }
 
     /**
@@ -90,9 +100,24 @@ public class Collection {
      */
     public JSONObject getRecord(String id) throws KintoException, ClientException {
         GetRequest request = kintoClient.request(ENDPOINTS.RECORD)
-                .routeParam("bucket", bucket.getName())
-                .routeParam("collection", name)
+                .routeParam("bucket", bucket.getId())
+                .routeParam("collection", this.id)
                 .routeParam("record", id);
         return kintoClient.execute(request);
+    }
+
+    /**
+     * Retrieve a record from the current collection as an object
+     * @param id the record id to retrieve
+     * @return the record as a T object
+     * @throws KintoException in case of error response from Kinto
+     * @throws ClientException in case of transport error
+     */
+    public <T> T getRecord(String id, Class<? extends T> clazz) throws KintoException, ClientException {
+        GetRequest request = kintoClient.request(ENDPOINTS.RECORD)
+                .routeParam("bucket", bucket.getId())
+                .routeParam("collection", this.id)
+                .routeParam("record", id);
+        return kintoClient.execute(request, clazz);
     }
 }

--- a/src/test/java/com/intesens/kinto_http/BucketTest.java
+++ b/src/test/java/com/intesens/kinto_http/BucketTest.java
@@ -1,7 +1,7 @@
 package com.intesens.kinto_http;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -58,15 +58,16 @@ public class BucketTest {
                 assertThat(getRequest.getHeaders(), is(expectedHeaders));
                 // AND the get method is used
                 assertThat(getRequest.getHttpMethod(), is(HttpMethod.GET));
-                return new JSONObject("{}");
+                return new JSONObject("{data:[{id: \"col1\"},{id:\"col2\"}]}");
             }
         })
                 .when(kintoClient)
                 .execute(any(GetRequest.class));
         // WHEN calling listBuckets
-        JSONObject jsonObject = kintoClient.bucket("bucketName").listCollections();
+        Set<Collection> collections = kintoClient.bucket("bucketName").listCollections();
         // THEN check if the answer is correctly called by checking the result
-        assertThat(jsonObject.toString(), is("{}"));
+
+        assertThat(collections.size(), is(2));
     }
 
     @Test
@@ -78,13 +79,13 @@ public class BucketTest {
         // AND a collection name
         String collectionName = "collectionName";
         // AND a bucket name
-        String bucketName = "bucketName";
+        String bucketId = "bucketId";
         // WHEN calling bucket.collection
-        Collection collection = kintoClient.bucket(bucketName).collection(collectionName);
+        Collection collection = kintoClient.bucket(bucketId).collection(collectionName);
         // THEN collection has a name
-        assertThat(collection.getName(), is(collectionName));
+        assertThat(collection.getId(), is(collectionName));
         // AND the collection has a bucket (with a name)
-        assertThat(collection.getBucket().getName(), is(bucketName));
+        assertThat(collection.getBucket().getId(), is(bucketId));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class BucketTest {
         // WHEN calling bucket
         Bucket bucket = kintoClient.bucket("bucketName");
         // THEN check if the answer is correctly called by checking the result
-        assertThat(bucket.getName(), is("bucketName"));
+        assertThat(bucket.getId(), is("bucketName"));
     }
 
 }

--- a/src/test/java/com/intesens/kinto_http/KintoClientTest.java
+++ b/src/test/java/com/intesens/kinto_http/KintoClientTest.java
@@ -175,7 +175,7 @@ public class KintoClientTest {
         // WHEN calling bucket
         Bucket bucket = kintoClient.bucket(bucketName);
         // THEN bucket have a name
-        assertThat(bucket.getName(), is(bucketName));
+        assertThat(bucket.getId(), is(bucketName));
     }
 
     @Test

--- a/src/test/java/com/intesens/kinto_http/ObjectMapperTest.java
+++ b/src/test/java/com/intesens/kinto_http/ObjectMapperTest.java
@@ -1,0 +1,197 @@
+package com.intesens.kinto_http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.mashape.unirest.http.ObjectMapper;
+
+/**
+ * Test class illustrating deserialization of record objects. This example uses Jackson as a JSON mapper.
+ * Created by jmarty on 25/09/16.
+ */
+public class ObjectMapperTest {
+
+    private KintoClient kintoClient;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(6706);
+
+    @Before
+    public void setUp() throws Exception {
+        com.fasterxml.jackson.databind.ObjectMapper jacksonMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper() {
+            @Override
+            public <T> T readValue(String value, Class<T> valueType) {
+                try {
+                    return jacksonMapper.readValue(value, valueType);
+                } catch (IOException e) {
+                    throw new RuntimeException("cannot deserialize", e);
+                }
+            }
+
+            @Override
+            public String writeValue(Object value) {
+                try {
+                    return jacksonMapper.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("cannot serialize", e);
+                }
+            }
+        };
+        this.kintoClient = new KintoClient("http://0.0.0.0:6706", mapper);
+    }
+
+    @Test
+    public void testDeserializeRecord() throws Exception {
+        // GIVEN a mock server that answers a json object
+        String bucket = "mybucket";
+        String collection = "mycollection";
+        String record = "myrecord";
+        String requestPath = ENDPOINTS.RECORD.getPath()
+                .replace("{bucket}", bucket)
+                .replace("{collection}", collection)
+                .replace("{record}", record);
+        wireMockRule.stubFor(get(urlPathEqualTo(requestPath))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json; charset=UTF-8")
+                        .withBody("{\"data\": {\"foo\": \"bar\", \"echo\": \"charlie\"}}")));
+
+        // WHEN the client queries the record as a DomainObject class
+        DomainObject actual = this.kintoClient.bucket(bucket).collection(collection).getRecord(record, DomainObject.class);
+
+        // THEN I get the expected DomainObject object
+        DomainObject expectedDomainObject = new DomainObject();
+        expectedDomainObject.getProperties().put("foo", "bar");
+        expectedDomainObject.getProperties().put("echo", "charlie");
+        assertThat(actual, is(expectedDomainObject));
+    }
+
+    @Test
+    public void testDezerializeRecords() throws Exception {
+        // GIVEN a mock server that answers a json array
+        String bucket = "mybucket";
+        String collection = "mycollection";
+        String requestPath = ENDPOINTS.RECORDS.getPath()
+                .replace("{bucket}", bucket)
+                .replace("{collection}", collection);
+        wireMockRule.stubFor(get(urlPathEqualTo(requestPath))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json; charset=UTF-8")
+                        .withBody("{\"data\": [{\"foo\": \"bar\"}, {\"foo\": \"baz\"}]}")));
+
+        // WHEN the client queries the record as a DomainObject class
+        RecordWrapper actual = this.kintoClient.bucket(bucket).collection(collection)
+                .listRecords(RecordWrapper.class);
+
+        // THEN I get the expected DomainObject object
+        OtherDomainObject barObject = new OtherDomainObject("bar");
+        OtherDomainObject bazObject = new OtherDomainObject("baz");
+        assertThat(actual, is(not(nullValue())));
+        assertThat(actual.getValues(), is(not(nullValue())));
+        assertThat(actual.getValues(), hasItem(barObject));
+        assertThat(actual.getValues(), hasItem(bazObject));
+    }
+
+    static class DomainObject {
+
+        @JsonProperty("data")
+        private Map<String, String> properties;
+
+        public DomainObject() {
+            this.properties = new HashMap<>();
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, String> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DomainObject domainObject = (DomainObject) o;
+
+            return properties.equals(domainObject.properties);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return properties.hashCode();
+        }
+    }
+
+    /**
+     * It is necessary to wrap kinto 'collection' responses in an object as we cannot directly dezerialize the "data"
+     * property from the response as a collection of custom objects.
+     */
+    static class RecordWrapper {
+        @JsonProperty("data")
+        private List<OtherDomainObject> values;
+
+        public RecordWrapper() {
+        }
+
+        public List<OtherDomainObject> getValues() {
+            return values;
+        }
+
+        public void setValues(List<OtherDomainObject> values) {
+            this.values = values;
+        }
+    }
+
+    static class OtherDomainObject {
+
+        private String foo;
+
+        public OtherDomainObject() {
+        }
+
+        public OtherDomainObject(String foo) {
+            this.foo = foo;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OtherDomainObject that = (OtherDomainObject) o;
+
+            return foo != null ? foo.equals(that.foo) : that.foo == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            return foo != null ? foo.hashCode() : 0;
+        }
+    }
+}


### PR DESCRIPTION
- Bucket.java : renamed "name" to "id", listCollections() returns a Set of Collection objects instead of a raw JSONObject
- Collection.java : renamed "name" to "id", listRecords() returns a Set of JSONObject instead of a raw JSONObject, added a parameterized getRecord method
- Added an ObjectMapper test class to illustrate how one would deserialize records as objects using Jackson
